### PR TITLE
PR: Refactor Monster Page by Extracting Components

### DIFF
--- a/apps/web/src/app/[locale]/(protected)/monster/components/monsterCard.tsx
+++ b/apps/web/src/app/[locale]/(protected)/monster/components/monsterCard.tsx
@@ -1,0 +1,21 @@
+import { Monster } from "../types";
+import Image from "next/image";
+
+type MonsterCardProps = {
+    monster: Monster;
+};
+
+export function MonsterCard({ monster }: MonsterCardProps) {
+    return (
+        <div className="flex w-40 flex-shrink-0 flex-col items-center justify-center p-2">
+            <Image
+                src={monster.image}
+                alt={monster.name}
+                width={96}
+                height={96}
+                className="h-24 w-24 object-contain drop-shadow-lg"
+            />
+            <span className="mt-2 text-sm">{monster.name}</span>
+        </div>
+    );
+}

--- a/apps/web/src/app/[locale]/(protected)/monster/components/monsterStrip.tsx
+++ b/apps/web/src/app/[locale]/(protected)/monster/components/monsterStrip.tsx
@@ -1,0 +1,24 @@
+import { MonsterCard } from "./monsterCard";
+import { Monster } from "../types";
+
+export type MonsterStripProps = {
+    monsters: Monster[];
+    offset: number;
+    duration: number;
+};
+
+export function MonsterStrip({ monsters, offset, duration }: MonsterStripProps) {
+    return (
+        <div
+            className="flex transition-transform ease-out"
+            style={{
+                transform: `translateX(-${offset}px)`,
+                transitionDuration: `${duration}ms`,
+            }}
+        >
+            {monsters.map((monster, idx) => (
+                <MonsterCard key={idx} monster={monster} />
+            ))}
+        </div>
+    );
+}

--- a/apps/web/src/app/[locale]/(protected)/monster/components/roller.tsx
+++ b/apps/web/src/app/[locale]/(protected)/monster/components/roller.tsx
@@ -1,0 +1,10 @@
+import { MonsterStrip, MonsterStripProps } from "./monsterStrip";
+
+export function Roller(props: MonsterStripProps) {
+    return (
+        <div className="relative mx-auto flex h-48 w-[640px] overflow-hidden rounded-lg border-4 border-green-600 bg-black">
+            <div className="absolute top-0 left-1/2 z-10 h-full w-1 -translate-x-1/2 transform bg-red-500" />
+            <MonsterStrip {...props} />
+        </div>
+    );
+}

--- a/apps/web/src/app/[locale]/(protected)/monster/hooks/useMonsterCase.ts
+++ b/apps/web/src/app/[locale]/(protected)/monster/hooks/useMonsterCase.ts
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import { Monster } from "../types";
+
+const ITEM_WIDTH = 160;
+const CONTAINER_WIDTH = 640;
+const SPIN_ROUNDS = 3;
+const ANIMATION_DURATION = 4000;
+
+export function useMonsterCase(monsters: Monster[]) {
+    const [selected, setSelected] = useState<Monster | null>(null);
+    const [rolling, setRolling] = useState(false);
+    const [offset, setOffset] = useState(0);
+
+    const handleOpen = () => {
+        if (rolling) return;
+
+        setRolling(true);
+        const chosen = getRandomMonster(monsters);
+        setSelected(chosen);
+
+        const chosenIndex = monsters.findIndex((m) => m.name === chosen.name);
+        const centerOffset = CONTAINER_WIDTH / 2 - ITEM_WIDTH / 2;
+        const finalOffset =
+            (monsters.length * SPIN_ROUNDS + chosenIndex) * ITEM_WIDTH - centerOffset;
+
+        setOffset(finalOffset);
+        setTimeout(() => setRolling(false), ANIMATION_DURATION);
+    };
+
+    return { selected, rolling, offset, handleOpen };
+}
+
+function getRandomMonster(monsters: Monster[]): Monster {
+    return monsters[Math.floor(Math.random() * monsters.length)];
+}

--- a/apps/web/src/app/[locale]/(protected)/monster/page.tsx
+++ b/apps/web/src/app/[locale]/(protected)/monster/page.tsx
@@ -1,16 +1,12 @@
 "use client";
 
-import { useState } from "react";
-import Image from "next/image";
 import { useTranslations } from "next-intl";
+import { Monster } from "./types";
+import { useMonsterCase } from "./hooks/useMonsterCase";
+import { Roller } from "./components/roller";
 
 // if you later need to fetch user info from session you need this:
 // export const dynamic = "force-dynamic";
-
-type Monster = {
-    name: string;
-    image: string;
-};
 
 const monsters: Monster[] = [
     { name: "Original", image: "/monsters/original.png" },
@@ -24,48 +20,20 @@ const monsters: Monster[] = [
     { name: "Ultra Rosa", image: "/monsters/ultra_rosa.png" },
 ];
 
-const ITEM_WIDTH = 160;
-const CONTAINER_WIDTH = 640;
 const SPIN_ROUNDS = 3;
 const ANIMATION_DURATION = 4000;
 
-function getRandomMonster(): Monster {
-    return monsters[Math.floor(Math.random() * monsters.length)];
-}
-
 export default function MonsterPage() {
-    const [selected, setSelected] = useState<Monster | null>(null);
-    const [rolling, setRolling] = useState(false);
-    const [offset, setOffset] = useState(0);
+    const { selected, rolling, offset, handleOpen } = useMonsterCase(monsters);
     const t = useTranslations("monster");
 
-    const handleOpen = () => {
-        if (rolling) return;
-
-        setRolling(true);
-        const chosen = getRandomMonster();
-        setSelected(chosen);
-
-        const chosenIndex = monsters.findIndex((m) => m.name === chosen.name);
-        const centerOffset = CONTAINER_WIDTH / 2 - ITEM_WIDTH / 2;
-
-        const finalOffset =
-            (monsters.length * SPIN_ROUNDS + chosenIndex) * ITEM_WIDTH - centerOffset;
-
-        setOffset(finalOffset);
-
-        setTimeout(() => setRolling(false), ANIMATION_DURATION);
-    };
-
-    const repeatedMonsters = Array(SPIN_ROUNDS + 2)
+    const repeatedMonsters: Monster[] = Array(SPIN_ROUNDS + 2)
         .fill(monsters)
-
         .flat();
 
     return (
         <div className="flex h-full flex-col items-center justify-center gap-6 text-center text-white">
             <h1 className="text-5xl font-bold">{t("title")}</h1>
-
             <button
                 className="rounded bg-green-600 px-6 py-3 text-xl font-semibold transition hover:bg-green-700 disabled:opacity-50"
                 onClick={handleOpen}
@@ -73,38 +41,7 @@ export default function MonsterPage() {
             >
                 {rolling ? t("rolling") : t("button_text")}
             </button>
-
-            {/* Case-opening strip */}
-            <div className="relative mx-auto flex h-48 w-[640px] overflow-hidden rounded-lg border-4 border-green-600 bg-black">
-                {/* highlight line */}
-                <div className="absolute top-0 left-1/2 z-10 h-full w-1 -translate-x-1/2 transform bg-red-500" />
-
-                <div
-                    className="flex transition-transform ease-out"
-                    style={{
-                        transform: `translateX(-${offset}px)`,
-                        transitionDuration: `${ANIMATION_DURATION}ms`,
-                    }}
-                >
-                    {repeatedMonsters.map((monster, idx) => (
-                        <div
-                            key={idx}
-                            className="flex w-40 flex-shrink-0 flex-col items-center justify-center p-2"
-                        >
-                            <Image
-                                src={monster.image}
-                                alt={monster.name}
-                                width={96}
-                                height={96}
-                                className="h-24 w-24 object-contain drop-shadow-lg"
-                            />
-                            <span className="mt-2 text-sm">{monster.name}</span>
-                        </div>
-                    ))}
-                </div>
-            </div>
-
-            {/* Reveal chosen monster name after roll */}
+            <Roller monsters={repeatedMonsters} offset={offset} duration={ANIMATION_DURATION} />
             {!rolling && selected && <div className="mt-4 text-3xl font-bold">{selected.name}</div>}
         </div>
     );

--- a/apps/web/src/app/[locale]/(protected)/monster/types.ts
+++ b/apps/web/src/app/[locale]/(protected)/monster/types.ts
@@ -1,0 +1,4 @@
+export type Monster = {
+    name: string;
+    image: string;
+};


### PR DESCRIPTION
This PR refactors the Monster case opening page by modularizing its UI and logic into reusable components:
- Extracted MonsterCard, MonsterStrip and Roller components for better separation, readability and reusability
- Centralized prop types for consistency across components
- No functionality changes, just structural improvements