### PR TITLE
feat: enforce widget creation limits and permissions

### DIFF
--- a/services/spring/src/main/java/dev/thehub/backend/widgets/create/CreateWidgetController.java
+++ b/services/spring/src/main/java/dev/thehub/backend/widgets/create/CreateWidgetController.java
@@ -5,7 +5,6 @@ import java.net.URI;
 import java.util.EnumSet;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -55,14 +54,15 @@ public class CreateWidgetController {
             return ResponseEntity.badRequest().body(Map.of("error", "invalid_request"));
         }
 
+        // Only allow kinds you actually support right now
         EnumSet<WidgetKind> supported = EnumSet.of(WidgetKind.SERVER_PINGS, WidgetKind.GROCERY_DEALS);
         if (!supported.contains(body.kind())) {
             return ResponseEntity.badRequest().body(Map.of("error", "unsupported_kind", "message",
                     "Supported kinds: " + supported.stream().map(WidgetKind::getValue).toList()));
         }
 
-        boolean isAdmin = auth.getAuthorities().stream().map(GrantedAuthority::getAuthority).collect(Collectors.toSet())
-                .contains("ROLE_ADMIN");
+        boolean isAdmin = auth.getAuthorities().stream().map(GrantedAuthority::getAuthority)
+                .anyMatch("ROLE_ADMIN"::equals);
 
         // Non-admins: only grocery-deals
         if (!isAdmin && body.kind() != WidgetKind.GROCERY_DEALS) {
@@ -70,16 +70,8 @@ public class CreateWidgetController {
                     .body(Map.of("error", "forbidden", "message", "Only admins can create this widget type."));
         }
 
-        if (!isAdmin) {
-            int current = service.countByUserAndKind(userId, WidgetKind.GROCERY_DEALS);
-            if (current >= 5) {
-                return ResponseEntity.status(409).body(
-                        Map.of("error", "limit_reached", "message", "You can have at most 5 grocery-deals widgets."));
-            }
-        }
-
-        // Cap: non-admins max 5 grocery-deals
-        if (!isAdmin) {
+        // Non-admins: cap grocery-deals at 5
+        if (!isAdmin && body.kind() == WidgetKind.GROCERY_DEALS) {
             int current = service.countByUserAndKind(userId, WidgetKind.GROCERY_DEALS);
             if (current >= 5) {
                 return ResponseEntity.status(409).body(

--- a/services/spring/src/main/java/dev/thehub/backend/widgets/create/CreateWidgetController.java
+++ b/services/spring/src/main/java/dev/thehub/backend/widgets/create/CreateWidgetController.java
@@ -31,32 +31,25 @@ public class CreateWidgetController {
         // Only allow kinds you actually support right now
         EnumSet<WidgetKind> supported = EnumSet.of(WidgetKind.SERVER_PINGS, WidgetKind.GROCERY_DEALS);
         if (!supported.contains(body.kind())) {
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "unsupported_kind",
-                    "message", "Supported kinds: " + supported.stream().map(WidgetKind::getValue).toList()
-            ));
+            return ResponseEntity.badRequest().body(Map.of("error", "unsupported_kind", "message",
+                    "Supported kinds: " + supported.stream().map(WidgetKind::getValue).toList()));
         }
 
-        boolean isAdmin = auth.getAuthorities().stream()
-                .map(GrantedAuthority::getAuthority)
+        boolean isAdmin = auth.getAuthorities().stream().map(GrantedAuthority::getAuthority)
                 .anyMatch("ROLE_ADMIN"::equals);
 
         // Non-admins: only grocery-deals
         if (!isAdmin && body.kind() != WidgetKind.GROCERY_DEALS) {
-            return ResponseEntity.status(403).body(Map.of(
-                    "error", "forbidden",
-                    "message", "Only admins can create this widget type."
-            ));
+            return ResponseEntity.status(403)
+                    .body(Map.of("error", "forbidden", "message", "Only admins can create this widget type."));
         }
 
         // Non-admins: cap grocery-deals at 5
         if (!isAdmin && body.kind() == WidgetKind.GROCERY_DEALS) {
             int current = service.countByUserAndKind(userId, WidgetKind.GROCERY_DEALS);
             if (current >= 5) {
-                return ResponseEntity.status(409).body(Map.of(
-                        "error", "limit_reached",
-                        "message", "You can have at most 5 grocery-deals widgets."
-                ));
+                return ResponseEntity.status(409).body(
+                        Map.of("error", "limit_reached", "message", "You can have at most 5 grocery-deals widgets."));
             }
         }
 

--- a/services/spring/src/main/java/dev/thehub/backend/widgets/create/CreateWidgetService.java
+++ b/services/spring/src/main/java/dev/thehub/backend/widgets/create/CreateWidgetService.java
@@ -48,6 +48,12 @@ public class CreateWidgetService {
         }
     }
 
+    public int countByUserAndKind(UUID userId, WidgetKind kind) {
+        final String sql = "select count(*) from user_widgets where user_id = ? and kind = ?";
+        Integer n = jdbc.queryForObject(sql, Integer.class, userId, kind.getValue());
+        return (n != null) ? n : 0;
+    }
+
     private void ensureNoDuplicateGroceries(UUID userId, WidgetKind kind, Map<String, Object> settings) {
         if (settings == null)
             throw new IllegalArgumentException("settings_required");


### PR DESCRIPTION
- Add user-specific widget count check to restrict non-admins to a maximum of 5 `grocery-deals` widgets.
- Restrict non-admins from creating widgets other than `grocery-deals`.
- Remove `@PreAuthorize` annotation in favor of role-based authority checks within the controller.
- Improve error responses for better clarity on limits and permissions.