### PR TITLE
Add widget editing and partial update functionality

### DIFF
--- a/apps/web/src/app/api/widgets/[id]/route.ts
+++ b/apps/web/src/app/api/widgets/[id]/route.ts
@@ -49,3 +49,45 @@ export async function DELETE(_req: NextRequest, ctx: Ctx) {
 
     return NextResponse.json({ ok: true });
 }
+
+export async function PATCH(req: NextRequest, ctx: Ctx) {
+    const { id } = await ctx.params; // await dynamic params
+    const backend = process.env.BACKEND_URL;
+    if (!backend) return NextResponse.json({ error: "BACKEND_URL not set" }, { status: 500 });
+    if (!id) return NextResponse.json({ error: "Missing id" }, { status: 400 });
+
+    // server-side log (shows in your Node terminal)
+    console.log("[PATCH /api/widgets/:id] params.id=", id);
+
+    const supabase = await createClient();
+    const {
+        data: { session },
+    } = await supabase.auth.getSession();
+    const token = session?.access_token;
+    if (!token) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+
+    const body = await req.json().catch(() => ({}));
+    console.log("[PATCH /api/widgets/:id] body=", body);
+
+    const response = await fetch(`${backend}/api/widgets/${encodeURIComponent(id)}`, {
+        method: "PATCH",
+        headers: {
+            "content-type": "application/json",
+            Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(body),
+    });
+
+    // Try to parse JSON if present
+    const ct = response.headers.get("content-type") ?? "";
+    const json = ct.includes("application/json") ? await response.json().catch(() => ({})) : {};
+
+    if (!response.ok) {
+        let message = (isRecord(json) && typeof json.error === "string" && json.error) || "Failed to update widget";
+        if (response.status === 401) message = "You need to sign in to edit widgets.";
+        else if (response.status === 403) message = "You’re not allowed to edit this widget.";
+        return NextResponse.json({ error: message }, { status: response.status });
+    }
+
+    return NextResponse.json(json);
+}

--- a/apps/web/src/components/widgets/WidgetsGrid/WidgetContainer.tsx
+++ b/apps/web/src/components/widgets/WidgetsGrid/WidgetContainer.tsx
@@ -63,7 +63,7 @@ export default function WidgetContainer({
     const header: ReactElement = <Header title={title} />;
     const actions: ReactElement = (
         <>
-            {isEditableKind(widget.kind) ? <EditWidgetButton widget={widget} /> : null}
+            {isEditableKind(widget.kind) ? <EditWidgetButton widget={widget} userId={userId ?? undefined} /> : null}
             <DeleteWidgetButton
                 widgetId={widget.instanceId}
                 widgetTitle={widgetTitle || kindLabel}

--- a/apps/web/src/components/widgets/WidgetsGrid/WidgetContainer.tsx
+++ b/apps/web/src/components/widgets/WidgetsGrid/WidgetContainer.tsx
@@ -6,6 +6,8 @@ import WidgetCard from "@/components/widgets/WidgetCard";
 import GlassCard from "@/components/ui/GlassCard";
 import { DeleteWidgetButton } from "@/components/widgets/delete/DeleteWidgetButton";
 import { useTranslations } from "next-intl";
+import { EditWidgetButton } from "@/components/widgets/edit/EditWidgetButton";
+import { isEditableKind } from "@/widgets/create/registry";
 
 type TitleMode = "title" | "query" | "auto";
 
@@ -60,12 +62,15 @@ export default function WidgetContainer({
 
     const header: ReactElement = <Header title={title} />;
     const actions: ReactElement = (
-        <DeleteWidgetButton
-            widgetId={widget.instanceId}
-            widgetTitle={widgetTitle || kindLabel}
-            userId={userId}
-            kind={widget.kind}
-        />
+        <>
+            {isEditableKind(widget.kind) ? <EditWidgetButton widget={widget} /> : null}
+            <DeleteWidgetButton
+                widgetId={widget.instanceId}
+                widgetTitle={widgetTitle || kindLabel}
+                userId={userId}
+                kind={widget.kind}
+            />
+        </>
     );
 
     return (

--- a/apps/web/src/components/widgets/_internal/SeedWidgetsCacheWithRows.tsx
+++ b/apps/web/src/components/widgets/_internal/SeedWidgetsCacheWithRows.tsx
@@ -7,11 +7,7 @@ import { API } from "@/lib/apiRoutes";
 export default function SeedWidgetsCacheWithRows({ rows }: { rows: WidgetListItem[] }) {
     // build a stable signature from instanceIds; order-insensitive
     const sig = useMemo(
-        () =>
-            rows
-                .map((r) => r.instanceId)
-                .sort()
-                .join("|"),
+        () => JSON.stringify(rows.map(r => ({ id: r.id, instanceId: r.instanceId, title: r.title }))),
         [rows]
     );
     const lastSig = useRef<string | null>(null);

--- a/apps/web/src/components/widgets/edit/EditWidgetButton.tsx
+++ b/apps/web/src/components/widgets/edit/EditWidgetButton.tsx
@@ -4,13 +4,13 @@ import { useState, type ReactElement } from "react";
 import type { AnyWidget } from "@/widgets/schema";
 import EditWidgetModal from "@/components/widgets/edit/EditWidgetModal";
 import { IconButton } from "@/components/ui/IconButton";
-import { Pencil, PencilLine } from "lucide-react";
+import { Pencil } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { isEditableKind } from "@/widgets/create/registry"; // helper we added earlier
+import { isEditableKind } from "@/widgets/create/registry";
 
-type Props = { widget: AnyWidget; compact?: boolean; forceDisabledTooltip?: string };
+type EditWidgetButtonProps = { widget: AnyWidget; forceDisabledTooltip?: string; userId?: string };
 
-export function EditWidgetButton({ widget, compact, forceDisabledTooltip }: Props): ReactElement {
+export function EditWidgetButton({ widget, forceDisabledTooltip, userId }: EditWidgetButtonProps): ReactElement {
     const t = useTranslations("widgets.edit");
     const [open, setOpen] = useState(false);
 
@@ -34,7 +34,7 @@ export function EditWidgetButton({ widget, compact, forceDisabledTooltip }: Prop
                 <Pencil className="h-4 w-4" aria-hidden />
             </IconButton>
 
-            {open ? <EditWidgetModal widget={widget} onClose={() => setOpen(false)} /> : null}
+            {open ? <EditWidgetModal widget={widget} userId={userId} onClose={() => setOpen(false)} /> : null}
         </>
     );
 }

--- a/apps/web/src/components/widgets/edit/EditWidgetButton.tsx
+++ b/apps/web/src/components/widgets/edit/EditWidgetButton.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState, type ReactElement } from "react";
+import type { AnyWidget } from "@/widgets/schema";
+import EditWidgetModal from "@/components/widgets/edit/EditWidgetModal";
+import { IconButton } from "@/components/ui/IconButton";
+import { Pencil, PencilLine } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { isEditableKind } from "@/widgets/create/registry"; // helper we added earlier
+
+type Props = { widget: AnyWidget; compact?: boolean; forceDisabledTooltip?: string };
+
+export function EditWidgetButton({ widget, compact, forceDisabledTooltip }: Props): ReactElement {
+    const t = useTranslations("widgets.edit");
+    const [open, setOpen] = useState(false);
+
+    const editable = isEditableKind(widget.kind);
+    const aria = t("ariaEdit", { default: "Edit widget" });
+
+    return (
+        <>
+            <IconButton
+                aria-label={aria}
+                title={
+                    editable
+                        ? aria
+                        : (forceDisabledTooltip ??
+                          t("notEditable", { default: "Not editable yet" }))
+                }
+                onClick={() => editable && setOpen(true)}
+                disabled={!editable}
+                className={editable ? "cursor-pointer" : "cursor-not-allowed opacity-60"}
+            >
+                <Pencil className="h-4 w-4" aria-hidden />
+            </IconButton>
+
+            {open ? <EditWidgetModal widget={widget} onClose={() => setOpen(false)} /> : null}
+        </>
+    );
+}

--- a/apps/web/src/components/widgets/edit/EditWidgetModal.tsx
+++ b/apps/web/src/components/widgets/edit/EditWidgetModal.tsx
@@ -9,13 +9,16 @@ import type { AnyWidget } from "@/widgets/schema";
 import { useCreateWidgetForm } from "@/widgets/create/useCreateWidgetForm";
 import { isEditableKind } from "@/widgets/create/registry";
 import { updateWidget } from "@/lib/widgets/updateWidget";
+import {purgeWidgetLocalCache} from "@/lib/widgets/purgeCaches";
 
 export default function EditWidgetModal({
     widget,
     onClose,
+    userId
 }: {
     widget: AnyWidget;
     onClose: () => void;
+    userId?: string | null;
 }): ReactElement {
     const t = useTranslations("widgets.edit");
     const router = useRouter();
@@ -64,6 +67,7 @@ export default function EditWidgetModal({
                     const res = await updateWidget(widget.instanceId, values);
                     if (res.ok) {
                         onClose();
+                        purgeWidgetLocalCache(userId, widget.kind, widget.instanceId);
                         router.refresh();
                     } else {
                         form.setError("root", { type: "server", message: res.error });

--- a/apps/web/src/components/widgets/edit/EditWidgetModal.tsx
+++ b/apps/web/src/components/widgets/edit/EditWidgetModal.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { ReactElement, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Modal } from "@/components/ui/Modal";
+import { Button, FieldText } from "@/components/ui/Fields";
+import { useTranslations } from "next-intl";
+import type { AnyWidget } from "@/widgets/schema";
+import { useCreateWidgetForm } from "@/widgets/create/useCreateWidgetForm";
+import { isEditableKind } from "@/widgets/create/registry";
+import { updateWidget } from "@/lib/widgets/updateWidget";
+
+export default function EditWidgetModal({
+    widget,
+    onClose,
+}: {
+    widget: AnyWidget;
+    onClose: () => void;
+}): ReactElement {
+    const t = useTranslations("widgets.edit");
+    const router = useRouter();
+
+    if (!isEditableKind(widget.kind)) {
+        // If opened somehow (deep link etc.), show a friendly message
+        return (
+            <Modal title={t("title", { default: "Edit widget" })} onClose={onClose}>
+                <div className="space-y-4">
+                    <p className="text-sm text-neutral-700">
+                        {t("unsupported", {
+                            default: "Editing isn’t available for this widget type yet.",
+                        })}
+                    </p>
+                    <div className="flex justify-end">
+                        <Button variant="outline" onClick={onClose}>
+                            {t("close", { default: "Close" })}
+                        </Button>
+                    </div>
+                </div>
+            </Modal>
+        );
+    }
+
+    const { form, active } = useCreateWidgetForm(widget.kind, t);
+    const Settings = active.SettingsForm;
+
+    useEffect(() => {
+        // Seed in the same shape your SettingsForm expects (usually nested under `settings`)
+        form.reset({
+            title: widget.title ?? "",
+            kind: widget.kind,
+            settings: widget.settings ?? {},
+        } as any);
+    }, [form, widget]);
+
+    return (
+        <Modal
+            title={t("title", { default: "Edit widget" })}
+            subtitle={t("subtitle", { default: "Update the name or settings and save." })}
+            onClose={onClose}
+        >
+            <form
+                className="space-y-4 text-left"
+                onSubmit={form.handleSubmit(async (values) => {
+                    const res = await updateWidget(widget.instanceId, values);
+                    if (res.ok) {
+                        onClose();
+                        router.refresh();
+                    } else {
+                        form.setError("root", { type: "server", message: res.error });
+                    }
+                })}
+            >
+                <FieldText
+                    label={t("name", { default: "Name" })}
+                    placeholder={t("namePlaceholder", { default: "My widget" })}
+                    error={form.formState.errors.title?.message}
+                    {...form.register("title")}
+                />
+
+                <input type="hidden" {...form.register("kind")} value={widget.kind} />
+
+                {/* @ts-expect-error form is specialized per kind */}
+                <Settings form={form} isEdit />
+
+                {form.formState.errors.root?.message ? (
+                    <div className="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-800">
+                        {form.formState.errors.root.message}
+                    </div>
+                ) : null}
+
+                <div className="flex items-center justify-end gap-2 pt-2">
+                    <Button variant="outline" onClick={onClose}>
+                        {t("cancel", { default: "Cancel" })}
+                    </Button>
+                    <Button type="submit">
+                        {form.formState.isSubmitting
+                            ? t("saving", { default: "Saving…" })
+                            : t("save", { default: "Save" })}
+                    </Button>
+                </div>
+            </form>
+        </Modal>
+    );
+}

--- a/apps/web/src/lib/widgets/updateWidget.ts
+++ b/apps/web/src/lib/widgets/updateWidget.ts
@@ -1,0 +1,17 @@
+import { API } from "@/lib/apiRoutes";
+import { parseError } from "@/utils/http";
+
+export async function updateWidget(id: string, payload: Record<string, unknown>) {
+    try {
+        const res = await fetch(API.widgets.byId(id), {
+            method: "PATCH",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(payload),
+            credentials: "same-origin",
+        });
+        if (!res.ok) return { ok: false as const, error: await parseError(res) };
+        return { ok: true as const };
+    } catch (e) {
+        return { ok: false as const, error: e instanceof Error ? e.message : "Network error" };
+    }
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -139,6 +139,28 @@
             "delete": "Delete",
             "deleting": "Deleting…",
             "genericError": "Something went wrong. Please try again."
+        },
+        "edit": {
+            "title": "Edit widget",
+            "subtitle": "Update the name or settings and save.",
+            "ariaEdit": "Edit widget",
+            "name": "Name",
+            "namePlaceholder": "My widget",
+            "save": "Save",
+            "saving": "Saving…",
+            "cancel": "Cancel",
+            "close": "Close",
+            "notEditable": "Not editable",
+            "notEditableTip": "Editing not available yet for this widget type.",
+            "unsupported": "Editing isn’t available for this widget type yet.",
+            "errors": {
+                "titleRequired": "Please enter a name.",
+                "updateFailed": "Failed to update widget.",
+                "unauthorized": "You need to sign in to edit widgets.",
+                "forbidden": "You’re not allowed to edit this widget.",
+                "network": "Network error while updating widget.",
+                "generic": "Something went wrong."
+            }
         }
     }
 }

--- a/apps/web/src/messages/no.json
+++ b/apps/web/src/messages/no.json
@@ -139,6 +139,28 @@
             "delete": "Slett",
             "deleting": "Sletter…",
             "genericError": "Noe gikk galt. Prøv igjen."
+        },
+        "edit": {
+            "title": "Rediger widget",
+            "subtitle": "Oppdater navn eller innstillinger og lagre.",
+            "ariaEdit": "Rediger widget",
+            "name": "Navn",
+            "namePlaceholder": "Min widget",
+            "save": "Lagre",
+            "saving": "Lagrer…",
+            "cancel": "Avbryt",
+            "close": "Lukk",
+            "notEditable": "Kan ikke redigeres",
+            "notEditableTip": "Redigering er foreløpig ikke tilgjengelig for denne widget-typen.",
+            "unsupported": "Redigering er ikke tilgjengelig for denne widget-typen ennå.",
+            "errors": {
+                "titleRequired": "Skriv inn et navn.",
+                "updateFailed": "Kunne ikke oppdatere widget.",
+                "unauthorized": "Du må være innlogget for å redigere widgets.",
+                "forbidden": "Du har ikke tilgang til å redigere denne widgeten.",
+                "network": "Nettverksfeil under oppdatering.",
+                "generic": "Noe gikk galt."
+            }
         }
     }
 }

--- a/apps/web/src/widgets/create/registry.tsx
+++ b/apps/web/src/widgets/create/registry.tsx
@@ -75,5 +75,11 @@ export const creationRegistry = {
 export type CreationRegistry = typeof creationRegistry;
 export type CreationKind = keyof CreationRegistry;
 
+export type EditableKind = CreationKind;
+
+export function isEditableKind(kind: WidgetKind): kind is EditableKind {
+    return kind in creationRegistry;
+}
+
 // Derive the dropdown list at runtime
 export const ENABLED_KINDS = Object.keys(creationRegistry) as CreationKind[];

--- a/services/spring/src/main/java/dev/thehub/backend/widgets/update/UpdateWidgetController.java
+++ b/services/spring/src/main/java/dev/thehub/backend/widgets/update/UpdateWidgetController.java
@@ -1,0 +1,84 @@
+package dev.thehub.backend.widgets.update;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Widgets")
+@RestController
+@RequestMapping("/api/widgets")
+public class UpdateWidgetController {
+
+    private static final Logger log = LoggerFactory.getLogger(UpdateWidgetController.class);
+
+    private final UpdateWidgetService service;
+
+    /**
+     * Constructs the controller handling partial update operations for widgets.
+     *
+     * @param service
+     *            business service that performs validation and persistence
+     */
+    public UpdateWidgetController(UpdateWidgetService service) {
+        this.service = service;
+    }
+
+    /**
+     * Applies a partial update to a widget owned by the authenticated user.
+     *
+     * <p>
+     * Supported fields in the payload are documented in
+     * {@link UpdateWidgetRequest}. The endpoint returns:
+     * <ul>
+     * <li>200 with the updated widget payload on success.</li>
+     * <li>404 if the instance does not exist or is not owned by the user.</li>
+     * <li>400 for validation errors (e.g., blank title, invalid JSON).</li>
+     * <li>409 if the update would result in a duplicate according to business
+     * rules.</li>
+     * <li>500 on unexpected errors.</li>
+     * </ul>
+     */
+    @Operation(summary = "Partially update a widget", description = "Updates title, grid, and/or settings for a widget owned by the current user. Null fields are ignored. Settings are merged and nulls are stripped.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Updated", content = @Content(schema = @Schema(implementation = dev.thehub.backend.widgets.create.CreateWidgetResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Bad request"),
+            @ApiResponse(responseCode = "404", description = "Not found or not owned"),
+            @ApiResponse(responseCode = "409", description = "Duplicate according to business rules"),
+            @ApiResponse(responseCode = "500", description = "Internal error")})
+    @PatchMapping("/{instanceId}")
+    public ResponseEntity<?> patch(@Parameter(hidden = true) JwtAuthenticationToken auth, @PathVariable UUID instanceId,
+            @RequestBody UpdateWidgetRequest body) {
+        final UUID userId = UUID.fromString(auth.getToken().getClaimAsString("sub"));
+        log.info("UpdateWidget PATCH start userId={} instanceId={} title?={} settings?={} grid?={}", userId, instanceId,
+                body.title() != null, body.settings() != null, body.grid() != null);
+
+        try {
+            var resp = service.partialUpdate(userId, instanceId, body);
+            log.info("UpdateWidget PATCH ok userId={} instanceId={}", userId, instanceId);
+            return ResponseEntity.ok(resp);
+        } catch (UpdateWidgetService.NotFoundOrNotOwned e) {
+            log.warn("UpdateWidget not_found userId={} instanceId={}", userId, instanceId);
+            return ResponseEntity.status(404).body(Map.of("error", "not_found"));
+        } catch (IllegalArgumentException e) {
+            log.warn("UpdateWidget bad_request userId={} instanceId={} msg={}", userId, instanceId, e.getMessage());
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        } catch (UpdateWidgetService.DuplicateException e) {
+            log.warn("UpdateWidget duplicate userId={} instanceId={} msg={}", userId, instanceId, e.getMessage());
+            return ResponseEntity.status(409).body(Map.of("error", "duplicate", "message", e.getMessage()));
+        } catch (Exception e) {
+            log.error("UpdateWidget internal_error userId={} instanceId={}", userId, instanceId, e);
+            return ResponseEntity.internalServerError().body(Map.of("error", "internal_error"));
+        }
+    }
+}

--- a/services/spring/src/main/java/dev/thehub/backend/widgets/update/UpdateWidgetRequest.java
+++ b/services/spring/src/main/java/dev/thehub/backend/widgets/update/UpdateWidgetRequest.java
@@ -1,0 +1,22 @@
+package dev.thehub.backend.widgets.update;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Map;
+
+/**
+ * Request payload for partially updating a widget.
+ *
+ * <p>
+ * All fields are optional. Any non-null value will be applied:
+ * <ul>
+ * <li>title — new title; if provided, it must not be blank after trimming.</li>
+ * <li>settings — partial settings to merge into existing settings (null values
+ * are stripped).</li>
+ * <li>grid — full grid object to replace the existing one.</li>
+ * </ul>
+ */
+public record UpdateWidgetRequest(
+        @Schema(description = "New title; if provided, must not be blank after trimming") String title,
+        @Schema(description = "Partial settings to merge into existing settings; nulls are stripped") Map<String, Object> settings,
+        @Schema(description = "Full grid object to replace the existing one") Map<String, Object> grid) {
+}

--- a/services/spring/src/main/java/dev/thehub/backend/widgets/update/UpdateWidgetService.java
+++ b/services/spring/src/main/java/dev/thehub/backend/widgets/update/UpdateWidgetService.java
@@ -1,0 +1,187 @@
+package dev.thehub.backend.widgets.update;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.thehub.backend.widgets.WidgetKind;
+import dev.thehub.backend.widgets.WidgetRow;
+import dev.thehub.backend.widgets.WidgetSettingsRepository;
+import dev.thehub.backend.widgets.create.CreateWidgetResponse;
+import dev.thehub.backend.widgets.create.CreateWidgetService;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UpdateWidgetService {
+
+    private static final Logger log = LoggerFactory.getLogger(UpdateWidgetService.class);
+
+    /**
+     * Thrown when a widget cannot be found for the given user/instance pair, or the
+     * widget exists but does not belong to the user.
+     */
+    public static class NotFoundOrNotOwned extends RuntimeException {
+    }
+    /**
+     * Thrown when the current user is not allowed to perform the requested update.
+     */
+    public static class Forbidden extends RuntimeException {
+    }
+    /**
+     * Thrown when the update would violate uniqueness constraints enforced by
+     * business rules (e.g., duplicate targets for SERVER_PINGS or duplicate
+     * query/city for GROCERY_DEALS).
+     */
+    public static class DuplicateException extends RuntimeException {
+        public DuplicateException(String msg) {
+            super(msg);
+        }
+    }
+
+    private final JdbcTemplate jdbc;
+    private final ObjectMapper json;
+    private final WidgetSettingsRepository readRepo;
+    private final CreateWidgetService createChecks;
+
+    /**
+     * Constructs the service responsible for partial updates of widgets.
+     *
+     * @param jdbc
+     *            database access via JdbcTemplate
+     * @param json
+     *            ObjectMapper for JSON operations
+     * @param readRepo
+     *            repository used to locate and read existing widget rows
+     * @param createChecks
+     *            delegate used to reuse duplicate-check logic from creation
+     */
+    public UpdateWidgetService(JdbcTemplate jdbc, ObjectMapper json, WidgetSettingsRepository readRepo,
+            CreateWidgetService createChecks) {
+        this.jdbc = jdbc;
+        this.json = json;
+        this.readRepo = readRepo;
+        this.createChecks = createChecks;
+    }
+
+    /**
+     * Applies a partial update to a widget owned by the given user.
+     *
+     * <p>
+     * Behavior:
+     * <ul>
+     * <li>title: If provided and non-blank after trim, updates the title; blank
+     * triggers 400.</li>
+     * <li>grid: If provided, replaces the grid JSON.</li>
+     * <li>settings: If provided, merges into existing settings (null values
+     * stripped) and enforces duplicate rules.</li>
+     * </ul>
+     *
+     * @param userId
+     *            owner id
+     * @param instanceId
+     *            widget instance id
+     * @param body
+     *            partial update payload
+     * @return a CreateWidgetResponse formatted response of the updated entity
+     * @throws NotFoundOrNotOwned
+     *             if no such widget for user/instance
+     * @throws DuplicateException
+     *             if settings would conflict with uniqueness constraints
+     * @throws IllegalArgumentException
+     *             for invalid inputs (e.g., blank title, invalid JSON)
+     */
+    public CreateWidgetResponse partialUpdate(UUID userId, UUID instanceId, UpdateWidgetRequest body) {
+        log.debug("UpdateWidgetService.enter userId={} instanceId={}", userId, instanceId);
+        var row = readRepo.findWidget(userId, instanceId).orElseThrow(NotFoundOrNotOwned::new);
+
+        WidgetKind kind = WidgetKind.from(row.kind());
+        String newTitle = (body.title() == null) ? null : body.title().trim();
+        if (newTitle != null && newTitle.isEmpty()) {
+            throw new IllegalArgumentException("title_required");
+        }
+
+        Map<String, Object> newSettings = body.settings();
+        Map<String, Object> newGrid = body.grid();
+
+        log.debug("UpdateWidgetService.validate kind={} titleChanged={} settingsChanged={} gridChanged={}", kind,
+                newTitle != null, newSettings != null, newGrid != null);
+
+        if (newSettings != null && !jsonEquals(newSettings, row.settings())) {
+            try {
+                createChecks.ensureNoDuplicateExceptInstance(userId, kind, newSettings, instanceId);
+            } catch (CreateWidgetService.DuplicateException e) {
+                // Map to our service's DuplicateException so the controller returns 409 (not
+                // 500)
+                throw new DuplicateException(e.getMessage());
+            }
+        }
+
+        final String sql = """
+                    update user_widgets
+                       set title   = coalesce(?, title),
+                           grid    = coalesce(?::jsonb, grid),
+                           settings = case
+                                        when ?::jsonb is null then settings
+                                        else jsonb_strip_nulls(settings || ?::jsonb)
+                                      end
+                     where user_id = ? and instance_id = ?
+                     returning id, instance_id, kind, title, grid, settings
+                """;
+
+        String gridJson = toJsonOrNull(newGrid);
+        String settingsJson = toJsonOrNull(newSettings);
+
+        return jdbc.query(con -> {
+            var ps = con.prepareStatement(sql);
+            ps.setString(1, newTitle); // nullable
+            ps.setString(2, gridJson); // nullable
+            ps.setString(3, settingsJson); // nullable check
+            ps.setString(4, settingsJson); // merge payload
+            ps.setObject(5, userId);
+            ps.setObject(6, instanceId);
+            return ps;
+        }, rs -> {
+            if (!rs.next())
+                throw new NotFoundOrNotOwned();
+            var updated = new WidgetRow(rs.getObject("id", UUID.class), rs.getObject("instance_id", UUID.class),
+                    rs.getString("kind"), rs.getString("title"), parseJson(rs.getString("grid")),
+                    parseJson(rs.getString("settings")));
+            return toCreateResponse(updated);
+        });
+    }
+
+    private String toJsonOrNull(Map<String, Object> m) {
+        if (m == null)
+            return null;
+        try {
+            return json.writeValueAsString(m);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("invalid_json");
+        }
+    }
+
+    private CreateWidgetResponse toCreateResponse(WidgetRow row) {
+        // Reuse your existing response format
+        return new CreateWidgetResponse(row.id().toString(), row.instanceId().toString(), WidgetKind.from(row.kind()),
+                row.title(), json.convertValue(row.grid(), Map.class), json.convertValue(row.settings(), Map.class));
+    }
+
+    private JsonNode parseJson(String s) {
+        try {
+            return (s != null && !s.isBlank()) ? json.readTree(s) : json.getNodeFactory().objectNode();
+        } catch (Exception ignored) {
+            return json.getNodeFactory().objectNode();
+        }
+    }
+
+    private boolean jsonEquals(Object a, Object b) {
+        try {
+            return json.valueToTree(a).equals(json.valueToTree(b));
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
```
### Description

This pull request introduces the following updates:

- **Signature Update**: Refactored `SeedWidgetsCacheWithRows` to include additional row properties.
- **PATCH Route & Utility**: Added `updateWidget` utility function and configured a PATCH route for widget updates.
- **Cache Management on Edit**: Passed `userId` to `EditWidgetButton` and implemented cache purging post-editing.
- **Partial Updates**: Enabled partial widget updates with in-built validation and duplicate prevention mechanisms.
- **Editing Support**: Improved widget editing with proper validation checks.

### Checklist

- [ ] Code changes are tested.
- [ ] Documentation is updated where necessary.
```