### PR TITLE
Adjust countdown widget polling and tick logic

### DIFF
--- a/apps/web/src/widgets/countdown/index.ts
+++ b/apps/web/src/widgets/countdown/index.ts
@@ -9,5 +9,5 @@ export const entry: Entry<"countdown"> = {
         return fetchJson(`${API.widgets.countdown}?${qs}`);
     },
     Component: CountdownView,
-    pollMs: 60_000,
+    pollMs: 3 * 60 * 60 * 1000, // 3 hours (21600000)
 };

--- a/apps/web/src/widgets/countdown/view.tsx
+++ b/apps/web/src/widgets/countdown/view.tsx
@@ -34,19 +34,25 @@ export default function CountdownView({
         const intervalMs = showHours ? 1000 : 60_000;
 
         const start = () => {
-            if (!tickRef.current) tickRef.current = window.setInterval(() => setNow(new Date()), intervalMs);
+            if (!tickRef.current) {
+                tickRef.current = window.setInterval(() => setNow(new Date()), intervalMs);
+            }
         };
         const stop = () => {
-            if (tickRef.current) { window.clearInterval(tickRef.current); tickRef.current = null; }
+            if (tickRef.current) {
+                window.clearInterval(tickRef.current);
+                tickRef.current = null;
+            }
         };
         const onVis = () => (document.visibilityState === "visible" ? start() : stop());
 
         start();
         document.addEventListener("visibilitychange", onVis);
-        return () => { stop(); document.removeEventListener("visibilitychange", onVis); };
+        return () => {
+            stop();
+            document.removeEventListener("visibilitychange", onVis);
+        };
     }, [showHours]);
-
-
 
     const label = useMemo(() => {
         if (widget.settings.source === "provider") {
@@ -61,7 +67,7 @@ export default function CountdownView({
     const prev = data?.previousIso ? new Date(data.previousIso) : null;
 
     const nextDate = next && next.getTime() > now.getTime() ? next : null;
-    const remaining = Math.max(0, nextDate ? nextDate.getTime() - now.getTime() : 0);
+    const remaining = nextDate ? nextDate.getTime() - now.getTime() : 0;
     const daysSincePrev = prev
         ? Math.floor((now.getTime() - prev.getTime()) / (24 * 3600 * 1000))
         : null;

--- a/apps/web/src/widgets/countdown/view.tsx
+++ b/apps/web/src/widgets/countdown/view.tsx
@@ -25,15 +25,17 @@ export default function CountdownView({
 }): ReactElement {
     const t = useTranslations("widgets.countdown.view");
 
+    // Tick every minute (or every second only if hours:minutes are shown)
+    const showHours = widget.settings.showHours ?? true;
     const [now, setNow] = useState<Date>(new Date());
     const tickRef = useRef<number | null>(null);
-
     useEffect(() => {
-        tickRef.current = window.setInterval(() => setNow(new Date()), 1000);
+        const intervalMs = showHours ? 1000 : 60_000;
+        tickRef.current = window.setInterval(() => setNow(new Date()), intervalMs);
         return () => {
             if (tickRef.current) window.clearInterval(tickRef.current);
         };
-    }, []);
+    }, [showHours]);
 
     const label = useMemo(() => {
         if (widget.settings.source === "provider") {
@@ -48,7 +50,6 @@ export default function CountdownView({
     const prev = data?.previousIso ? new Date(data.previousIso) : null;
 
     const nextDate = next && next.getTime() > now.getTime() ? next : null;
-
     const remaining = nextDate ? nextDate.getTime() - now.getTime() : 0;
     const daysSincePrev = prev
         ? Math.floor((now.getTime() - prev.getTime()) / (24 * 3600 * 1000))
@@ -61,7 +62,7 @@ export default function CountdownView({
             {nextDate ? (
                 <>
                     <div className="text-3xl font-bold tabular-nums">
-                        {fmtRemain(remaining, widget.settings.showHours ?? true)}
+                        {fmtRemain(remaining, showHours)}
                     </div>
                     <div className="text-xs opacity-70">
                         {nextDate.toLocaleString(undefined, {


### PR DESCRIPTION
Extended the polling interval of the countdown widget from 1 minute to 3 hours, improving efficiency. Updated tick behavior to dynamically adjust between 1-second and 1-minute increments based on the hour display.