### PR TITLE
Remove `title` field from widget operations and database models.

### DIFF
--- a/apps/web/src/app/api/widgets/seed/route.ts
+++ b/apps/web/src/app/api/widgets/seed/route.ts
@@ -5,7 +5,7 @@ import { widgetsCookieKeyFor } from "@/lib/widgets/cache.server";
 
 const CACHE_TTL_S = 60 * 60 * 24 * 7;
 
-type SlimWidget = Pick<WidgetListItem, "id" | "instanceId" | "kind" | "title" | "grid">;
+type SlimWidget = Pick<WidgetListItem, "id" | "instanceId" | "kind" | "grid">;
 
 function isSlimWidgetArray(x: unknown): x is SlimWidget[] {
     if (!Array.isArray(x)) return false;
@@ -16,7 +16,6 @@ function isSlimWidgetArray(x: unknown): x is SlimWidget[] {
             typeof o.id === "string" &&
             typeof o.instanceId === "string" &&
             typeof o.kind === "string" &&
-            typeof o.title === "string" &&
             typeof o.grid === "object" &&
             o.grid !== null
         );

--- a/apps/web/src/components/widgets/_internal/CreateWidgetModal.tsx
+++ b/apps/web/src/components/widgets/_internal/CreateWidgetModal.tsx
@@ -3,7 +3,7 @@
 import { ReactElement, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Modal } from "@/components/ui/Modal";
-import { Button, FieldText } from "@/components/ui/Fields";
+import { Button } from "@/components/ui/Fields";
 import { useTranslations } from "next-intl";
 import { creationRegistry, type CreationKind } from "@/widgets/create/registry";
 import { BaseForm, useCreateWidgetForm } from "@/widgets/create/useCreateWidgetForm";
@@ -61,13 +61,6 @@ export default function CreateWidgetModal({ onClose }: { onClose: () => void }):
                     })
                 )}
             >
-                <FieldText
-                    label={t("name")}
-                    placeholder={t("namePlaceholder")}
-                    error={form.formState.errors.title?.message}
-                    {...form.register("title")}
-                />
-
                 {/* hidden field to bind RHF value to state */}
                 <input type="hidden" {...form.register("kind")} value={kind} />
                 <KindSelect value={kind} onChange={setKind} t={t} />

--- a/apps/web/src/components/widgets/_internal/SeedWidgetsCacheWithRows.tsx
+++ b/apps/web/src/components/widgets/_internal/SeedWidgetsCacheWithRows.tsx
@@ -21,11 +21,10 @@ export default function SeedWidgetsCacheWithRows({ rows }: { rows: WidgetListIte
         if (sig === lastSig.current) return;
         lastSig.current = sig;
 
-        const slim = rows.map(({ id, instanceId, kind, title, grid }) => ({
+        const slim = rows.map(({ id, instanceId, kind, grid }) => ({
             id,
             instanceId,
             kind,
-            title,
             grid,
         }));
 

--- a/apps/web/src/components/widgets/edit/EditWidgetModal.tsx
+++ b/apps/web/src/components/widgets/edit/EditWidgetModal.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { Modal } from "@/components/ui/Modal";
-import { Button, FieldText } from "@/components/ui/Fields";
+import { Button } from "@/components/ui/Fields";
 import { useTranslations } from "next-intl";
 import type { AnyWidget } from "@/widgets/schema";
 import { type BaseForm, useCreateWidgetForm } from "@/widgets/create/useCreateWidgetForm";
@@ -88,13 +88,6 @@ function EditWidgetModalContent({
                     }
                 })}
             >
-                <FieldText
-                    label={t("name", { default: "Name" })}
-                    placeholder={t("namePlaceholder", { default: "My widget" })}
-                    error={form.formState.errors.title?.message}
-                    {...form.register("title")}
-                />
-
                 {/* keep kind bound in the form state */}
                 <input type="hidden" {...form.register("kind")} value={widget.kind} />
 

--- a/apps/web/src/components/widgets/edit/useEditWidgetPrefill.ts
+++ b/apps/web/src/components/widgets/edit/useEditWidgetPrefill.ts
@@ -10,7 +10,6 @@ type EditableWidget = Extract<AnyWidget, { kind: EditableKind }>;
 
 function buildEditDefaults(widget: EditableWidget): BaseForm {
     return {
-        title: widget.title ?? "",
         kind: widget.kind,
         settings: widget.settings ?? {},
     };

--- a/apps/web/src/lib/widgets/cache.server.ts
+++ b/apps/web/src/lib/widgets/cache.server.ts
@@ -11,7 +11,7 @@ export function widgetsCookieKeyFor(uid: string) {
 /**
  * Shape persisted in the cookie. We support two payload forms:
  *  - "rows": full array of WidgetListItem-like objects
- *  - "slim": minimal array (id, instanceId, kind, title, grid)
+ *  - "slim": minimal array (id, instanceId, kind, grid)
  *    (settings may be omitted for "slim")
  */
 type WidgetsCachePayload = {
@@ -25,7 +25,6 @@ function isSlimRow(x: unknown): x is {
     id: string;
     instanceId: string;
     kind: WidgetListItem["kind"];
-    title: string;
     grid: WidgetListItem["grid"];
     settings?: unknown;
 } {
@@ -36,7 +35,6 @@ function isSlimRow(x: unknown): x is {
         typeof obj.id === "string" &&
         typeof obj.instanceId === "string" &&
         typeof obj.kind === "string" &&
-        typeof obj.title === "string" &&
         typeof obj.grid === "object" &&
         obj.grid !== null
     );
@@ -67,7 +65,6 @@ export function normalizeCachedToRows(payload: {
             id: item.id,
             instanceId: item.instanceId,
             kind: item.kind,
-            title: item.title,
             grid: item.grid,
             // settings can be absent in "slim"; the consumer (toAnyWidget) will fill defaults per kind
             settings: item.settings ?? undefined,
@@ -102,11 +99,10 @@ export async function readWidgetsCookie(currentUid: string | null): Promise<{
 }
 
 export async function writeWidgetsCookieServer(uid: string, rows: WidgetListItem[]) {
-    const slim = rows.map(({ id, instanceId, kind, title, grid }) => ({
+    const slim = rows.map(({ id, instanceId, kind, grid }) => ({
         id,
         instanceId,
         kind,
-        title,
         grid,
     }));
 

--- a/apps/web/src/lib/widgets/createWidget.ts
+++ b/apps/web/src/lib/widgets/createWidget.ts
@@ -2,7 +2,6 @@ import { API } from "@/lib/apiRoutes";
 import { parseError } from "@/utils/http";
 
 export async function createWidget(payload: {
-    title: string;
     kind: string;
     settings: unknown;
     grid?: { x: number; y: number; w: number; h: number };

--- a/apps/web/src/widgets/countdown/settings.tsx
+++ b/apps/web/src/widgets/countdown/settings.tsx
@@ -7,7 +7,6 @@ import { countdownSettingsSchema } from "@/widgets/create/registry";
 import { useTranslations } from "next-intl";
 
 type FormType = UseFormReturn<{
-    title: string;
     kind: "countdown";
     settings: z.infer<typeof countdownSettingsSchema>;
 }>;

--- a/apps/web/src/widgets/create/onSubmitCreateWidget.ts
+++ b/apps/web/src/widgets/create/onSubmitCreateWidget.ts
@@ -18,7 +18,6 @@ export async function onSubmitCreateWidget(
     opts: { onSuccess: () => void; onError: (message: string) => void }
 ) {
     const res = await createWidget({
-        title: v.title,
         kind: v.kind,
         settings: v.settings,
         grid: { x: 0, y: 0, w: 1, h: 1 },

--- a/apps/web/src/widgets/create/registry.tsx
+++ b/apps/web/src/widgets/create/registry.tsx
@@ -88,7 +88,7 @@ export type CreateEntry<K extends WidgetKind, S extends z.ZodTypeAny> = {
     schema: S;
     defaults: z.infer<S>;
     SettingsForm: (props: {
-        form: UseFormReturn<{ title: string; kind: K; settings: z.infer<S> }>;
+        form: UseFormReturn<{ kind: K; settings: z.infer<S> }>;
     }) => ReactElement;
 };
 

--- a/apps/web/src/widgets/create/useCreateWidgetForm.ts
+++ b/apps/web/src/widgets/create/useCreateWidgetForm.ts
@@ -10,7 +10,7 @@ import {
     creationRegistry,
 } from "@/widgets/create/registry";
 
-export type BaseForm = { title: string; kind: CreationKind; settings: unknown };
+export type BaseForm = { kind: CreationKind; settings: unknown };
 
 export function useCreateWidgetForm(kind: CreationKind, t: (k: string) => string) {
     const active = creationRegistry[kind];
@@ -22,11 +22,10 @@ export function useCreateWidgetForm(kind: CreationKind, t: (k: string) => string
     const schema = useMemo(
         () =>
             z.object({
-                title: z.string().min(1, t("errors.titleRequired")),
                 kind: z.literal(active.kind),
                 settings: settingsSchema,
             }),
-        [active.kind, settingsSchema, t]
+        [active.kind, settingsSchema]
     );
 
     // bridge resolver types without `any`
@@ -35,17 +34,14 @@ export function useCreateWidgetForm(kind: CreationKind, t: (k: string) => string
     const form = useForm<BaseForm>({
         resolver,
         defaultValues: {
-            title: "",
             kind: active.kind,
             settings: active.defaults,
         },
     });
 
-    // when kind changes, swap defaults but keep title
     useEffect(() => {
         const next = creationRegistry[kind];
         form.reset({
-            title: form.getValues("title"),
             kind: next.kind,
             settings: next.defaults,
         });

--- a/apps/web/src/widgets/grocery-deals/types.ts
+++ b/apps/web/src/widgets/grocery-deals/types.ts
@@ -25,7 +25,6 @@ export type Deal = {
 };
 
 export type GroceryForm = UseFormReturn<{
-    title: string;
     kind: "grocery-deals";
     settings: z.infer<typeof grocerySettingsSchema>;
 }>;

--- a/apps/web/src/widgets/rows.ts
+++ b/apps/web/src/widgets/rows.ts
@@ -12,7 +12,6 @@ export type WidgetListItem = {
     id: string;
     instanceId: string;
     kind: WidgetKind;
-    title: string;
     grid: Grid;
     settings: unknown;
 };

--- a/apps/web/src/widgets/schema.ts
+++ b/apps/web/src/widgets/schema.ts
@@ -51,7 +51,6 @@ export type BaseWidget<K extends WidgetKind, S> = {
     id: string;
     instanceId: string;
     kind: K;
-    title: string;
     grid: Grid;
     settings: S;
 };

--- a/apps/web/src/widgets/server-pings/ServerPingSettings.tsx
+++ b/apps/web/src/widgets/server-pings/ServerPingSettings.tsx
@@ -5,7 +5,6 @@ import { serverPingsSettingsSchema } from "@/widgets/create/registry";
 import { z } from "zod";
 
 type ServerPingsForm = UseFormReturn<{
-    title: string;
     kind: "server-pings";
     settings: z.infer<typeof serverPingsSettingsSchema>;
 }>;

--- a/services/spring/src/main/java/dev/thehub/backend/widgets/WidgetRow.java
+++ b/services/spring/src/main/java/dev/thehub/backend/widgets/WidgetRow.java
@@ -12,12 +12,10 @@ import java.util.UUID;
  *            stable client-facing identifier (UUID)
  * @param kind
  *            widget kind as stored in DB (e.g., "server-pings")
- * @param title
- *            widget title
  * @param grid
  *            grid/layout configuration as JSON
  * @param settings
  *            widget settings JSON specific to its kind
  */
-public record WidgetRow(UUID id, UUID instanceId, String kind, String title, JsonNode grid, JsonNode settings) {
+public record WidgetRow(UUID id, UUID instanceId, String kind, JsonNode grid, JsonNode settings) {
 }

--- a/services/spring/src/main/java/dev/thehub/backend/widgets/WidgetSettingsRepository.java
+++ b/services/spring/src/main/java/dev/thehub/backend/widgets/WidgetSettingsRepository.java
@@ -43,7 +43,7 @@ public class WidgetSettingsRepository {
      */
     public Optional<WidgetRow> findWidget(UUID userId, UUID instanceId) {
         final String sql = """
-                select id, instance_id, kind, title, grid, settings
+                select id, instance_id, kind, grid, settings
                 from user_widgets
                 where user_id = ? and instance_id = ?
                 limit 1
@@ -53,7 +53,7 @@ public class WidgetSettingsRepository {
                 JsonNode grid = parseJson(rs.getString("grid"));
                 JsonNode settings = parseJson(rs.getString("settings"));
                 return new WidgetRow(rs.getObject("id", UUID.class), rs.getObject("instance_id", UUID.class),
-                        rs.getString("kind"), rs.getString("title"), grid, settings);
+                        rs.getString("kind"), grid, settings);
             }, userId, instanceId));
         } catch (EmptyResultDataAccessException e) {
             return Optional.empty();

--- a/services/spring/src/main/java/dev/thehub/backend/widgets/create/CreateWidgetController.java
+++ b/services/spring/src/main/java/dev/thehub/backend/widgets/create/CreateWidgetController.java
@@ -77,10 +77,9 @@ public class CreateWidgetController {
             @RequestBody CreateWidgetRequest body) {
         final UUID userId = UUID.fromString(auth.getToken().getClaimAsString("sub"));
 
-        log.info("CreateWidget request received userId={} kind={} title.len={}", userId, body.kind(),
-                body.title() == null ? 0 : body.title().length());
+        log.info("CreateWidget request received userId={} kind={}", userId, body.kind());
 
-        if (body.kind() == null || body.title() == null || body.title().isBlank()) {
+        if (body.kind() == null) {
             log.warn("CreateWidget invalid_request userId={}", userId);
             return ResponseEntity.badRequest().body(Map.of("error", "invalid_request"));
         }
@@ -114,7 +113,7 @@ public class CreateWidgetController {
 
         try {
             service.ensureNoDuplicate(userId, body.kind(), body.settings());
-            var resp = service.create(userId, body.kind(), body.title(), body.settings(), body.grid());
+            var resp = service.create(userId, body.kind(), body.settings(), body.grid());
             log.info("CreateWidget success userId={} instanceId={} kind={}", userId, resp.instanceId(), body.kind());
             return ResponseEntity.created(URI.create("/api/widgets/" + resp.instanceId())).body(resp);
         } catch (CreateWidgetService.DuplicateException | CreateWidgetService.DuplicateTargetException e) {

--- a/services/spring/src/main/java/dev/thehub/backend/widgets/create/CreateWidgetRequest.java
+++ b/services/spring/src/main/java/dev/thehub/backend/widgets/create/CreateWidgetRequest.java
@@ -6,8 +6,6 @@ import java.util.Map;
 /**
  * Request payload for creating a new widget.
  *
- * @param title
- *            the widget title (required, non-blank)
  * @param kind
  *            the kind of widget to create (currently supports
  *            {@link WidgetKind#SERVER_PINGS} and
@@ -18,6 +16,5 @@ import java.util.Map;
  * @param grid
  *            optional grid configuration for client layout (e.g., x, y, w, h)
  */
-public record CreateWidgetRequest(String title, WidgetKind kind, Map<String, Object> settings,
-        Map<String, Object> grid) {
+public record CreateWidgetRequest(WidgetKind kind, Map<String, Object> settings, Map<String, Object> grid) {
 }

--- a/services/spring/src/main/java/dev/thehub/backend/widgets/create/CreateWidgetResponse.java
+++ b/services/spring/src/main/java/dev/thehub/backend/widgets/create/CreateWidgetResponse.java
@@ -12,13 +12,11 @@ import java.util.Map;
  *            client-facing instance identifier (UUID string)
  * @param kind
  *            the widget kind
- * @param title
- *            the widget title
  * @param grid
  *            the stored grid configuration
  * @param settings
  *            the stored settings
  */
-public record CreateWidgetResponse(String id, String instanceId, WidgetKind kind, String title,
-        Map<String, Object> grid, Map<String, Object> settings) {
+public record CreateWidgetResponse(String id, String instanceId, WidgetKind kind, Map<String, Object> grid,
+        Map<String, Object> settings) {
 }

--- a/services/spring/src/main/java/dev/thehub/backend/widgets/list/WidgetsListController.java
+++ b/services/spring/src/main/java/dev/thehub/backend/widgets/list/WidgetsListController.java
@@ -52,7 +52,7 @@ public class WidgetsListController {
      *            {@link WidgetKind#from(String)})
      * @param includeSettings
      *            whether to include the settings JSON in the response
-     * @return list of maps containing id, instanceId, kind, title, grid, settings
+     * @return list of maps containing id, instanceId, kind, grid, settings
      */
     @GetMapping("/list")
     public List<Map<String, Object>> list(JwtAuthenticationToken auth, @RequestParam(required = false) String kind,
@@ -60,7 +60,7 @@ public class WidgetsListController {
         var userId = UUID.fromString(auth.getToken().getClaimAsString("sub"));
 
         String sql = """
-                select id, instance_id, kind, title, grid, settings
+                select id, instance_id, kind, grid, settings
                 from user_widgets
                 where user_id = ?
                 %s
@@ -98,8 +98,7 @@ public class WidgetsListController {
             }
 
             return Map.of("id", rs.getString("id"), "instanceId", rs.getObject("instance_id", UUID.class).toString(),
-                    "kind", rs.getString("kind"), "title", rs.getString("title"), "grid", grid, "settings",
-                    includeSettings ? settings : Map.of());
+                    "kind", rs.getString("kind"), "grid", grid, "settings", includeSettings ? settings : Map.of());
         });
 
         return rows;

--- a/services/spring/src/main/java/dev/thehub/backend/widgets/update/UpdateWidgetController.java
+++ b/services/spring/src/main/java/dev/thehub/backend/widgets/update/UpdateWidgetController.java
@@ -43,13 +43,13 @@ public class UpdateWidgetController {
      * <ul>
      * <li>200 with the updated widget payload on success.</li>
      * <li>404 if the instance does not exist or is not owned by the user.</li>
-     * <li>400 for validation errors (e.g., blank title, invalid JSON).</li>
+     * <li>400 for validation errors (e.g. JSON).</li>
      * <li>409 if the update would result in a duplicate according to business
      * rules.</li>
      * <li>500 on unexpected errors.</li>
      * </ul>
      */
-    @Operation(summary = "Partially update a widget", description = "Updates title, grid, and/or settings for a widget owned by the current user. Null fields are ignored. Settings are merged and nulls are stripped.")
+    @Operation(summary = "Partially update a widget", description = "Updates grid, and/or settings for a widget owned by the current user. Null fields are ignored. Settings are merged and nulls are stripped.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Updated", content = @Content(schema = @Schema(implementation = dev.thehub.backend.widgets.create.CreateWidgetResponse.class))),
             @ApiResponse(responseCode = "400", description = "Bad request"),
@@ -60,8 +60,8 @@ public class UpdateWidgetController {
     public ResponseEntity<?> patch(@Parameter(hidden = true) JwtAuthenticationToken auth, @PathVariable UUID instanceId,
             @RequestBody UpdateWidgetRequest body) {
         final UUID userId = UUID.fromString(auth.getToken().getClaimAsString("sub"));
-        log.info("UpdateWidget PATCH start userId={} instanceId={} title?={} settings?={} grid?={}", userId, instanceId,
-                body.title() != null, body.settings() != null, body.grid() != null);
+        log.info("UpdateWidget PATCH start userId={} instanceId={} settings?={} grid?={}", userId, instanceId,
+                body.settings() != null, body.grid() != null);
 
         try {
             var resp = service.partialUpdate(userId, instanceId, body);

--- a/services/spring/src/main/java/dev/thehub/backend/widgets/update/UpdateWidgetRequest.java
+++ b/services/spring/src/main/java/dev/thehub/backend/widgets/update/UpdateWidgetRequest.java
@@ -9,14 +9,12 @@ import java.util.Map;
  * <p>
  * All fields are optional. Any non-null value will be applied:
  * <ul>
- * <li>title — new title; if provided, it must not be blank after trimming.</li>
  * <li>settings — partial settings to merge into existing settings (null values
  * are stripped).</li>
  * <li>grid — full grid object to replace the existing one.</li>
  * </ul>
  */
 public record UpdateWidgetRequest(
-        @Schema(description = "New title; if provided, must not be blank after trimming") String title,
         @Schema(description = "Partial settings to merge into existing settings; nulls are stripped") Map<String, Object> settings,
         @Schema(description = "Full grid object to replace the existing one") Map<String, Object> grid) {
 }

--- a/supabase/migrations/20250909171537_drop_title_column.sql
+++ b/supabase/migrations/20250909171537_drop_title_column.sql
@@ -1,0 +1,1 @@
+alter table public.user_widgets drop column if exists title;


### PR DESCRIPTION
---

This pull request refactors the widget operations to remove all instances of the `title` field. Key changes include:

- `title` field removed from widget model definitions and related operations.
- Updates to creation and editing workflows to exclude the `title` field.
- Database migration to drop the `title` column from the `user_widgets` table.

No new functionality is introduced, and these changes aim to streamline the widget data structure.