### PR TITLE
Increase default data limit for etilbudsavis retrieval

### DIFF
--- a/services/spring/src/main/resources/application.properties
+++ b/services/spring/src/main/resources/application.properties
@@ -23,7 +23,7 @@ etilbudsavis.default-city=Trondheim
 etilbudsavis.default-lat=63.4306
 etilbudsavis.default-lon=10.4037
 etilbudsavis.country=NO
-etilbudsavis.default-limit=1
+etilbudsavis.default-limit=20
 etilbudsavis.timeout-seconds=6
 
 # --- Groceries widget ---


### PR DESCRIPTION
Updated the default limit for etilbudsavis in the groceries module to enhance data retrieval and address potential limitations. This change ensures better handling of larger datasets.