### PR TITLE
Enhance Dockerfile and CI workflow for versioning support

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -79,6 +79,8 @@ jobs:
           file: services/spring/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: false
+          build-args: |
+            APP_VERSION=dev
 
       # Build & Push on main only (push or manual dispatch)
       - name: Build & Push (GHCR)
@@ -89,6 +91,8 @@ jobs:
           file: services/spring/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            APP_VERSION=${{ steps.calver.outputs.tag }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/the-hub-api:latest
             ghcr.io/${{ github.repository_owner }}/the-hub-api:${{ steps.calver.outputs.tag }}

--- a/services/spring/Dockerfile
+++ b/services/spring/Dockerfile
@@ -15,6 +15,8 @@ RUN --mount=type=cache,target=/root/.m2 mvn -q -DskipTests package
 
 # --- prod runtime ---
 FROM eclipse-temurin:21-jre-alpine AS prod
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
 # add curl for healthcheck
 RUN apk add --no-cache curl
 WORKDIR /app

--- a/services/spring/src/main/java/dev/thehub/backend/config/VersionLogger.java
+++ b/services/spring/src/main/java/dev/thehub/backend/config/VersionLogger.java
@@ -1,0 +1,30 @@
+package dev.thehub.backend.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+/**
+ * Logs the application version (CalVer when built by CI) at startup for easy
+ * identification in logs.
+ */
+@Component
+public class VersionLogger implements ApplicationRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(VersionLogger.class);
+
+    private final Environment environment;
+
+    public VersionLogger(Environment environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        String version = environment.getProperty("info.app.version", "unknown");
+        log.info("App version: {}", version);
+    }
+}

--- a/services/spring/src/main/resources/application.properties
+++ b/services/spring/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 # --- App ---
 spring.application.name=backend
 server.port=8080
+info.app.version=${APP_VERSION:unknown}
 server.forward-headers-strategy=framework
 
 # --- Actuator ---


### PR DESCRIPTION
This pull request introduces application versioning to the Spring backend service, ensuring that the app version (set during CI builds) is available as an environment variable and logged at startup. The changes span the CI workflow, Dockerfile, application properties, and application code to support this functionality.

**CI/CD and Docker build improvements:**
- The GitHub Actions workflow now passes an `APP_VERSION` build argument to the Docker build process, using `dev` for non-main builds and the CalVer tag for main builds. [[1]](diffhunk://#diff-d30b4e6a2bd3c346243a103c773373348c1bf4a80af7bf92f854306c597fca6bR82-R83) [[2]](diffhunk://#diff-d30b4e6a2bd3c346243a103c773373348c1bf4a80af7bf92f854306c597fca6bR94-R95)
- The `services/spring/Dockerfile` now accepts the `APP_VERSION` build argument and sets it as an environment variable in the runtime image.

**Application configuration and logging:**
- The `application.properties` file now maps `info.app.version` to the `APP_VERSION` environment variable, defaulting to `unknown` if unset.
- A new `VersionLogger` component logs the application version at startup, making it easy to identify which version is running from the logs.- Add APP_VERSION argument to Dockerfile for dynamic versioning.
- Update backend CI workflow to include APP_VERSION build arguments for both development and production environments.
- Introduce VersionLogger component to log application version at startup, improving traceability in logs.
- Modify application.properties to set app version from environment variable, defaulting to 'unknown' if not set.